### PR TITLE
Fix 4 model manifests: point to lquint/* ONNX repos with real SHA256 hashes

### DIFF
--- a/models/classification/DotnetAILab.ModelGarden.Classification.EmotionRoBERTa/model-manifest.json
+++ b/models/classification/DotnetAILab.ModelGarden.Classification.EmotionRoBERTa/model-manifest.json
@@ -1,19 +1,19 @@
 {
   "model": {
-    "id": "SamLowe/roberta-base-go_emotions",
+    "id": "lquint/roberta-base-go_emotions-onnx",
     "revision": "main",
     "files": [
       {
-        "path": "onnx/model.onnx",
-        "sha256": "TODO",
-        "size": 0
+        "path": "model.onnx",
+        "sha256": "039e4e0399f4167966b114258507f6f8d418651d234a283c7aa7afb736a1f66e",
+        "size": 498891623
       }
     ]
   },
   "sources": {
     "huggingface": {
       "type": "huggingface",
-      "repo": "SamLowe/roberta-base-go_emotions",
+      "repo": "lquint/roberta-base-go_emotions-onnx",
       "revision": "main"
     }
   },

--- a/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/model-manifest.json
+++ b/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/model-manifest.json
@@ -1,19 +1,19 @@
 {
   "model": {
-    "id": "MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli",
+    "id": "lquint/DeBERTa-v3-base-mnli-fever-anli-onnx",
     "revision": "main",
     "files": [
       {
-        "path": "onnx/model.onnx",
-        "sha256": "TODO",
-        "size": 0
+        "path": "model.onnx",
+        "sha256": "7bccfc660f3206d6601a531a07e857cd95830bd7375e90c6177580ee45d5c2ab",
+        "size": 738608072
       }
     ]
   },
   "sources": {
     "huggingface": {
       "type": "huggingface",
-      "repo": "MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli",
+      "repo": "lquint/DeBERTa-v3-base-mnli-fever-anli-onnx",
       "revision": "main"
     }
   },

--- a/models/qa/DotnetAILab.ModelGarden.QA.MiniLMSquad2/model-manifest.json
+++ b/models/qa/DotnetAILab.ModelGarden.QA.MiniLMSquad2/model-manifest.json
@@ -1,19 +1,19 @@
 {
   "model": {
-    "id": "deepset/minilm-uncased-squad2",
+    "id": "lquint/minilm-uncased-squad2-onnx",
     "revision": "main",
     "files": [
       {
-        "path": "onnx/model.onnx",
-        "sha256": "TODO",
-        "size": 0
+        "path": "model.onnx",
+        "sha256": "331f8a0f66eb9ac017b441f12bb3f21b8ed503e37ed8ef26a869c94ac5c4b5aa",
+        "size": 133062014
       }
     ]
   },
   "sources": {
     "huggingface": {
       "type": "huggingface",
-      "repo": "deepset/minilm-uncased-squad2",
+      "repo": "lquint/minilm-uncased-squad2-onnx",
       "revision": "main"
     }
   },

--- a/models/qa/DotnetAILab.ModelGarden.QA.RobertaSquad2/model-manifest.json
+++ b/models/qa/DotnetAILab.ModelGarden.QA.RobertaSquad2/model-manifest.json
@@ -1,19 +1,19 @@
 {
   "model": {
-    "id": "deepset/roberta-base-squad2",
+    "id": "lquint/roberta-base-squad2-onnx",
     "revision": "main",
     "files": [
       {
-        "path": "onnx/model.onnx",
-        "sha256": "TODO",
-        "size": 0
+        "path": "model.onnx",
+        "sha256": "26f5829beeaf81ed922c9edd56469cad81fc84678a4db0632cf5dd3d96f73a10",
+        "size": 496449283
       }
     ]
   },
   "sources": {
     "huggingface": {
       "type": "huggingface",
-      "repo": "deepset/roberta-base-squad2",
+      "repo": "lquint/roberta-base-squad2-onnx",
       "revision": "main"
     }
   },


### PR DESCRIPTION
## Summary

Update model-manifest.json for the 4 models that previously had no ONNX exports (placeholder `TODO` hashes and `size: 0`).

Pre-exported ONNX models are now hosted at `lquint/*` HuggingFace repos, created as part of upstream work in mlnet-text-inference-custom-transforms#17.

## Changes

| Model | Old Source | New Source | ONNX Size |
|-------|-----------|-----------|-----------|
| EmotionRoBERTa | `SamLowe/roberta-base-go_emotions` | `lquint/roberta-base-go_emotions-onnx` | 499 MB |
| ZeroShotDeBERTa | `MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli` | `lquint/DeBERTa-v3-base-mnli-fever-anli-onnx` | 739 MB |
| MiniLMSquad2 | `deepset/minilm-uncased-squad2` | `lquint/minilm-uncased-squad2-onnx` | 133 MB |
| RobertaSquad2 | `deepset/roberta-base-squad2` | `lquint/roberta-base-squad2-onnx` | 496 MB |

Per manifest:
- Model ID updated to `lquint/*-onnx` variant
- File path: `onnx/model.onnx` -> `model.onnx` (root level)
- SHA256: `TODO` -> real hash from HuggingFace CDN ETag
- Size: `0` -> actual file size in bytes

## Testing
- `dotnet build` passes for all 16 projects

Closes #1