### PR TITLE
Enable Phi3Mini multi-file model package

### DIFF
--- a/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/Phi3MiniModel.cs
+++ b/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/Phi3MiniModel.cs
@@ -14,10 +14,13 @@ public static class Phi3MiniModel
     private static readonly Lazy<ModelPackage> Package = new(() =>
         ModelPackage.FromManifestResource(typeof(Phi3MiniModel).Assembly));
 
-    /// <summary>Returns local path to the cached model directory.</summary>
-    public static Task<string> EnsureModelAsync(
+    /// <summary>Returns local path to the cached model directory containing all model files.</summary>
+    public static async Task<string> EnsureModelAsync(
         ModelOptions? options = null, CancellationToken ct = default)
-        => Package.Value.EnsureModelAsync(options, ct);
+    {
+        var files = await Package.Value.EnsureFilesAsync(options, ct);
+        return files.ModelDirectory;
+    }
 
     /// <summary>
     /// Creates a text generation transformer backed by the local ONNX model.

--- a/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/model-manifest.json
+++ b/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/model-manifest.json
@@ -5,33 +5,33 @@
     "files": [
       {
         "path": "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx",
-        "sha256": "TODO",
-        "size": 0
+        "sha256": "385cd1b908a0d2f8634e86d30236f6dbb7ae660eb3943fd1ef5bdc3847326480",
+        "size": 231335
       },
       {
         "path": "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx.data",
-        "sha256": "TODO",
-        "size": 0
+        "sha256": "",
+        "size": 2722861056
       },
       {
         "path": "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/genai_config.json",
-        "sha256": "TODO",
-        "size": 0
+        "sha256": "d5ec04466a3d080de412409bf762219628f375314cfff303976733364baec5a2",
+        "size": 1576
       },
       {
         "path": "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/tokenizer.model",
-        "sha256": "TODO",
-        "size": 0
+        "sha256": "9e556afd44213b6bd1be2b850ebbbd98f5481437a8021afaf58ee7fb1818d347",
+        "size": 499723
       },
       {
         "path": "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/tokenizer_config.json",
-        "sha256": "TODO",
-        "size": 0
+        "sha256": "32f66c2bab499baaa8341819ad9a13342f957501ce1e989bcb90853a01336cc0",
+        "size": 3441
       },
       {
         "path": "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/special_tokens_map.json",
-        "sha256": "TODO",
-        "size": 0
+        "sha256": "810adc6e6c6ef2f56c285ef930d243358a3a9f05e36a01c5a10bafc6fac4609b",
+        "size": 599
       }
     ]
   },


### PR DESCRIPTION
## Summary

Enable the Phi3Mini text generation model package by populating the 6-file manifest with real hashes/sizes and fixing the facade to use `EnsureFilesAsync()` + `ModelDirectory`.

## The Problem

Phi3Mini requires 6 files in a single directory (ONNX graph, weights, config, tokenizer). Before PR #16 in model-packages-prototype, `EnsureModelAsync()` only downloaded `Files[0]` and there was no API to download all files. The manifest had placeholder `TODO` hashes and `size: 0`.

## What Changed

### Manifest
- Real SHA256 hashes for 5 of 6 files (computed from HuggingFace downloads)
- Real file sizes for all 6 files (from HuggingFace API)
- `.onnx.data` (2.7GB weights) uses size-only verification (empty SHA256 = skip per upstream PR #14)

### Facade (`Phi3MiniModel.cs`)

**Before:**
```csharp
// Downloaded only Files[0], returned a FILE path
public static Task<string> EnsureModelAsync(...)
    => Package.Value.EnsureModelAsync(options, ct);
```

**After:**
```csharp
// Downloads ALL 6 files, returns the DIRECTORY path
public static async Task<string> EnsureModelAsync(...)
{
    var files = await Package.Value.EnsureFilesAsync(options, ct);
    return files.ModelDirectory;
}
```

OnnxGenAI needs a **directory** containing model + config + tokenizer files, not a single file path.

## Why No Upstream Fix Needed

After deep analysis, PR #16's `EnsureFilesAsync()` + `ModelFiles.ModelDirectory` is the correct API for this use case:

1. `EnsureFilesAsync()` downloads all manifest files 
2. `ModelFiles.ModelDirectory` gives `Path.GetDirectoryName(PrimaryModelPath)` 
3. All 6 Phi3Mini files share the prefix `cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/`, so they all resolve to the same cache directory 
4. Issue #3 (`EnsureModelDirectoryAsync` proposal) is functionally equivalent to `EnsureFilesAsync().ModelDirectory`  different name, same result

## File Layout in Cache
```
{LocalAppData}/ModelPackages/ModelCache/microsoft/Phi-3-mini-4k-instruct-onnx/main/
  cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/
    phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx      (231 KB)
    phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx.data (2.7 GB)
    genai_config.json                                                   (1.5 KB)
    tokenizer.model                                                     (500 KB)
    tokenizer_config.json                                               (3.4 KB)
    special_tokens_map.json                                             (599 B)
```

## Testing
- `dotnet build` passes for all 16 projects
- Cannot run end-to-end test (2.7GB model download)

Closes #4