### PR TITLE
feat: Apply upstream version tracking to 7 model packages

### DIFF
--- a/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa.csproj
+++ b/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa</PackageId>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <Description>DeBERTa-v3 zero-shot NLI classification model package. Model binary auto-downloads on first use via ModelPackages SDK.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/README.md
+++ b/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/README.md
@@ -257,11 +257,11 @@ Console.WriteLine($"\n→ Route to: {bestLabel} (confidence: {bestScore:P1})");
 
 ## Versioning
 
-This package's NuGet version tracks the upstream model version. The current version **3.0.0** corresponds to **[DeBERTa-v3-base-mnli-fever-anli](https://huggingface.co/lquint/DeBERTa-v3-base-mnli-fever-anli-onnx)**, where "v3" refers to the DeBERTa architecture version.
+This package's NuGet version tracks the upstream model version. The current version **3.0.0** corresponds to **[DeBERTa-v3-base-mnli-fever-anli-onnx](https://huggingface.co/lquint/DeBERTa-v3-base-mnli-fever-anli-onnx)**, where "v3" refers to the DeBERTa architecture version.
 
 | NuGet Version | Upstream Model |
 |---------------|---------------|
-| 3.0.x | DeBERTa-**v3**-base-mnli-fever-anli |
+| 3.0.x | DeBERTa-**v3**-base-mnli-fever-anli-onnx |
 
 When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
 

--- a/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/README.md
+++ b/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/README.md
@@ -255,6 +255,16 @@ Console.WriteLine($"\n→ Route to: {bestLabel} (confidence: {bestScore:P1})");
 - You're **prototyping** and want to iterate on categories quickly
 - You need to classify into **many niche categories** simultaneously
 
+## Versioning
+
+This package's NuGet version tracks the upstream model version. The current version **3.0.0** corresponds to **[DeBERTa-v3-base-mnli-fever-anli](https://huggingface.co/lquint/DeBERTa-v3-base-mnli-fever-anli-onnx)**, where "v3" refers to the DeBERTa architecture version.
+
+| NuGet Version | Upstream Model |
+|---------------|---------------|
+| 3.0.x | DeBERTa-**v3**-base-mnli-fever-anli |
+
+When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
+
 ## References
 
 - **DeBERTa-v3**: He et al., ["DeBERTaV3: Improving DeBERTa using ELECTRA-Style Pre-Training with Gradient-Disentangled Embedding Sharing"](https://arxiv.org/abs/2111.09543) (ICLR 2023)

--- a/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/model-manifest.json
+++ b/models/classification/DotnetAILab.ModelGarden.Classification.ZeroShotDeBERTa/model-manifest.json
@@ -1,6 +1,7 @@
 {
   "model": {
     "id": "lquint/DeBERTa-v3-base-mnli-fever-anli-onnx",
+    "version": "3.0.0",
     "revision": "main",
     "files": [
       {

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.AllMiniLM/DotnetAILab.ModelGarden.Embeddings.AllMiniLM.csproj
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.AllMiniLM/DotnetAILab.ModelGarden.Embeddings.AllMiniLM.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>DotnetAILab.ModelGarden.Embeddings.AllMiniLM</PackageId>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Description>all-MiniLM-L6-v2 embedding model package. Model binary auto-downloads on first use via ModelPackages SDK.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.AllMiniLM/README.md
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.AllMiniLM/README.md
@@ -286,6 +286,16 @@ static float CosineSimilarity(float[] a, float[] b)
 - **[DotnetAILab.ModelGarden.Embeddings.GteSmall](../DotnetAILab.ModelGarden.Embeddings.GteSmall/)** — GTE small, strong general-purpose embeddings by Alibaba DAMO.
 - **[DotnetAILab.ModelGarden.AudioEmbedding.CLAP](../../audioembeddings/DotnetAILab.ModelGarden.AudioEmbedding.CLAP/)** — CLAP audio embeddings for audio-text similarity tasks.
 
+## Versioning
+
+This package's NuGet version tracks the upstream model version. The current version **2.0.0** corresponds to **[all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)**, where "v2" refers to the model architecture version from sentence-transformers.
+
+| NuGet Version | Upstream Model |
+|---------------|---------------|
+| 2.0.x | all-MiniLM-L6-**v2** |
+
+When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
+
 ## References
 
 - [all-MiniLM-L6-v2 on Hugging Face](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.AllMiniLM/model-manifest.json
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.AllMiniLM/model-manifest.json
@@ -1,6 +1,7 @@
 {
   "model": {
     "id": "sentence-transformers/all-MiniLM-L6-v2",
+    "version": "2.0.0",
     "revision": "main",
     "files": [
       {

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn.csproj
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>DotnetAILab.ModelGarden.Embeddings.BgeSmallEn</PackageId>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Description>bge-small-en-v1.5 embedding model package. Model binary auto-downloads on first use via ModelPackages SDK.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn/README.md
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn/README.md
@@ -287,6 +287,16 @@ static float CosineSimilarity(float[] a, float[] b)
 - **[DotnetAILab.ModelGarden.Embeddings.GteSmall](../DotnetAILab.ModelGarden.Embeddings.GteSmall/)** — GTE small, strong general-purpose embeddings by Alibaba DAMO.
 - **[DotnetAILab.ModelGarden.AudioEmbedding.CLAP](../../audioembeddings/DotnetAILab.ModelGarden.AudioEmbedding.CLAP/)** — CLAP audio embeddings for audio-text similarity tasks.
 
+## Versioning
+
+This package's NuGet version tracks the upstream model version. The current version **1.5.0** corresponds to **[bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5)**, where "v1.5" is the version designated by BAAI.
+
+| NuGet Version | Upstream Model |
+|---------------|---------------|
+| 1.5.x | bge-small-en-**v1.5** |
+
+When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
+
 ## References
 
 - [bge-small-en-v1.5 on Hugging Face](https://huggingface.co/BAAI/bge-small-en-v1.5)

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn/model-manifest.json
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.BgeSmallEn/model-manifest.json
@@ -9,6 +9,7 @@
       }
     ],
     "id": "BAAI/bge-small-en-v1.5",
+    "version": "1.5.0",
     "revision": "main"
   },
   "sources": {

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.E5Small/DotnetAILab.ModelGarden.Embeddings.E5Small.csproj
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.E5Small/DotnetAILab.ModelGarden.Embeddings.E5Small.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>DotnetAILab.ModelGarden.Embeddings.E5Small</PackageId>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Description>e5-small-v2 embedding model package. Model binary auto-downloads on first use via ModelPackages SDK.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.E5Small/README.md
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.E5Small/README.md
@@ -309,6 +309,16 @@ static float CosineSimilarity(float[] a, float[] b)
 - **[DotnetAILab.ModelGarden.Embeddings.GteSmall](../DotnetAILab.ModelGarden.Embeddings.GteSmall/)** — GTE small, strong general-purpose embeddings by Alibaba DAMO.
 - **[DotnetAILab.ModelGarden.AudioEmbedding.CLAP](../../audioembeddings/DotnetAILab.ModelGarden.AudioEmbedding.CLAP/)** — CLAP audio embeddings for audio-text similarity tasks.
 
+## Versioning
+
+This package's NuGet version tracks the upstream model version. The current version **2.0.0** corresponds to **[e5-small-v2](https://huggingface.co/intfloat/e5-small-v2)**, where "v2" is the version designated by intfloat.
+
+| NuGet Version | Upstream Model |
+|---------------|---------------|
+| 2.0.x | e5-small-**v2** |
+
+When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
+
 ## References
 
 - [e5-small-v2 on Hugging Face](https://huggingface.co/intfloat/e5-small-v2)

--- a/models/embeddings/DotnetAILab.ModelGarden.Embeddings.E5Small/model-manifest.json
+++ b/models/embeddings/DotnetAILab.ModelGarden.Embeddings.E5Small/model-manifest.json
@@ -9,6 +9,7 @@
       }
     ],
     "id": "intfloat/e5-small-v2",
+    "version": "2.0.0",
     "revision": "main"
   },
   "sources": {

--- a/models/reranking/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM.csproj
+++ b/models/reranking/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM</PackageId>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Description>MS MARCO MiniLM L-6 v2 reranking model package. Model binary auto-downloads on first use via ModelPackages SDK.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/models/reranking/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM/README.md
+++ b/models/reranking/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM/README.md
@@ -231,6 +231,16 @@ var prompt = $"Context:\n{context}\n\nQuestion: {query}\nAnswer:";
 | BGE Reranker Base | Reranking (alternative) | `DotnetAILab.ModelGarden.Reranking.BgeReranker` |
 | Phi-3 Mini | Text generation | `DotnetAILab.ModelGarden.TextGeneration.Phi3Mini` |
 
+## Versioning
+
+This package's NuGet version tracks the upstream model version. The current version **2.0.0** corresponds to **[ms-marco-MiniLM-L-6-v2](https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2)**, where "v2" is the version designated by cross-encoder.
+
+| NuGet Version | Upstream Model |
+|---------------|---------------|
+| 2.0.x | ms-marco-MiniLM-L-6-**v2** |
+
+When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
+
 ## References
 
 - [cross-encoder/ms-marco-MiniLM-L-6-v2 on Hugging Face](https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2)

--- a/models/reranking/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM/model-manifest.json
+++ b/models/reranking/DotnetAILab.ModelGarden.Reranking.MsMarcoMiniLM/model-manifest.json
@@ -9,6 +9,7 @@
       }
     ],
     "id": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    "version": "2.0.0",
     "revision": "main"
   },
   "sources": {

--- a/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini.csproj
+++ b/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>DotnetAILab.ModelGarden.TextGeneration.Phi3Mini</PackageId>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <Description>Phi-3 Mini text generation model package. Model directory auto-downloads on first use via ModelPackages SDK. Uses ONNX Runtime GenAI for local inference.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/README.md
+++ b/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/README.md
@@ -255,6 +255,16 @@ public class TextData
 | AllMiniLM | Embeddings | `DotnetAILab.ModelGarden.Embeddings.AllMiniLM` |
 | BGE Small EN | Embeddings | `DotnetAILab.ModelGarden.Embeddings.BgeSmallEn` |
 
+## Versioning
+
+This package's NuGet version tracks the upstream model version. The current version **3.0.0** corresponds to **[Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx)**, where "3" refers to the Phi model generation.
+
+| NuGet Version | Upstream Model |
+|---------------|---------------|
+| 3.0.x | Phi-**3**-mini-4k-instruct |
+
+When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
+
 ## References
 
 - [microsoft/Phi-3-mini-4k-instruct-onnx on Hugging Face](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx)

--- a/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/README.md
+++ b/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/README.md
@@ -257,11 +257,11 @@ public class TextData
 
 ## Versioning
 
-This package's NuGet version tracks the upstream model version. The current version **3.0.0** corresponds to **[Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx)**, where "3" refers to the Phi model generation.
+This package's NuGet version tracks the upstream model version. The current version **3.0.0** corresponds to **[Phi-3-mini-4k-instruct-onnx](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx)**, where "3" refers to the Phi model generation.
 
 | NuGet Version | Upstream Model |
 |---------------|---------------|
-| 3.0.x | Phi-**3**-mini-4k-instruct |
+| 3.0.x | Phi-**3**-mini-4k-instruct-onnx |
 
 When the upstream model releases a new version, a new major version of this package will be published with an updated model binary.
 

--- a/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/model-manifest.json
+++ b/models/textgeneration/DotnetAILab.ModelGarden.TextGeneration.Phi3Mini/model-manifest.json
@@ -1,6 +1,7 @@
 {
   "model": {
     "id": "microsoft/Phi-3-mini-4k-instruct-onnx",
+    "version": "3.0.0",
     "revision": "main",
     "files": [
       {

--- a/models/vad/DotnetAILab.ModelGarden.VAD.SileroVad/model-manifest.json
+++ b/models/vad/DotnetAILab.ModelGarden.VAD.SileroVad/model-manifest.json
@@ -1,6 +1,7 @@
 {
   "model": {
     "id": "snakers4/silero-vad",
+    "version": "4.0.0",
     "revision": "main",
     "files": [
       {


### PR DESCRIPTION
## Summary

Apply upstream version tracking to the 7 model packages with identifiable upstream model versions.

### Changes per package

| Package | `model.version` (manifest) | `<VersionPrefix>` (csproj) | Upstream Model |
|---------|---------------------------|---------------------------|----------------|
| AllMiniLM | `2.0.0` | `2.0.0` | [all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) |
| BgeSmallEn | `1.5.0` | `1.5.0` | [bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) |
| E5Small | `2.0.0` | `2.0.0` | [e5-small-v2](https://huggingface.co/intfloat/e5-small-v2) |
| MsMarcoMiniLM | `2.0.0` | `2.0.0` | [ms-marco-MiniLM-L-6-v2](https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2) |
| ZeroShotDeBERTa | `3.0.0` | `3.0.0` | [DeBERTa-v3-base-mnli-fever-anli](https://huggingface.co/MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli) |
| Phi3Mini | `3.0.0` | `3.0.0` | [Phi-3-mini-4k-instruct-onnx](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx) |
| SileroVad | `4.0.0` | *(already set in PR #16)* | [silero-vad-v4-onnx](https://huggingface.co/lquint/silero-vad-v4-onnx) |

### What's NOT changed

14 packages without meaningful upstream versions keep the default `0.1.0` from `Directory.Build.props` (see Issue #19 body for the full list).

### Forward-compatible manifest `version` field

The `"version"` field added to `model-manifest.json` is **forward-compatible**: the current ModelPackages SDK (0.1.0-preview.14) silently ignores unknown JSON fields. When [model-packages-prototype#40](https://github.com/luisquintanilla/model-packages-prototype/issues/40) ships, `ModelInfo.Version` will expose it for runtime queryability.

### NuGet version behavior (CI)

With the `VersionSuffix` CI from PR #16:
- **Preview builds**: `2.0.0-preview.N`, `1.5.0-preview.N`, `3.0.0-preview.N`, etc.
- **Release builds**: `2.0.0`, `1.5.0`, `3.0.0`, etc.
- **Unversioned packages**: `0.1.0-preview.N` / `0.1.0` (unchanged)

### Files changed

- 7 `model-manifest.json`: added `"version"` field
- 6 `.csproj`: added `<VersionPrefix>`
- 6 `README.md`: added `## Versioning` section

Closes #19